### PR TITLE
Experiment firestore integration

### DIFF
--- a/code/app/build.gradle
+++ b/code/app/build.gradle
@@ -7,7 +7,7 @@ android {
 
     defaultConfig {
         applicationId "com.example.experiment_automata"
-        minSdkVersion 16
+        minSdkVersion 24
         targetSdkVersion 30
         versionCode 1
         versionName "1.0"

--- a/code/app/src/main/java/com/example/experiment_automata/Experiments/ExperimentModel/ExperimentManager.java
+++ b/code/app/src/main/java/com/example/experiment_automata/Experiments/ExperimentModel/ExperimentManager.java
@@ -1,8 +1,6 @@
 package com.example.experiment_automata.Experiments.ExperimentModel;
 
-import android.util.Log;
-
-import com.example.experiment_automata.Experiments.ExperimentModel.Experiment;
+import com.google.firebase.firestore.FirebaseFirestore;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -140,6 +138,17 @@ public class ExperimentManager
         }
         return experimentsList;
     }
+
+
+    /**
+     * Push all experiments to firestore
+     */
+    public void postAllToFirestore(){
+        FirebaseFirestore db = FirebaseFirestore.getInstance();
+        
+    }
+
+
 
     public Experiment query(UUID experimentId) {
         return experiments.get(experimentId);

--- a/code/app/src/main/java/com/example/experiment_automata/Experiments/ExperimentModel/ExperimentManager.java
+++ b/code/app/src/main/java/com/example/experiment_automata/Experiments/ExperimentModel/ExperimentManager.java
@@ -143,6 +143,15 @@ public class ExperimentManager
         return experimentsList;
     }
 
+    /**
+     * Get a specific Experiment from firestore
+     * @param experimentID
+     * The UUID of the requested experiment
+     */
+    public void getExperimentFromFirestore(UUID experimentID){
+        FirebaseFirestore db = FirebaseFirestore.getInstance();
+        
+    }
 
     /**
      * Push all experiments to firestore
@@ -165,7 +174,6 @@ public class ExperimentManager
         Map<String,Object> experimentData = new HashMap<>();
         String experimentUUIDString = experiment.getExperimentId().toString();
         String experimentOwnerString = experiment.getOwnerId().toString();//not sure if needed in DB
-
 
         experimentData.put("accepting-new-results",experiment.isActive());
         experimentData.put("description",experiment.getDescription());

--- a/code/app/src/main/java/com/example/experiment_automata/Experiments/ExperimentModel/ExperimentManager.java
+++ b/code/app/src/main/java/com/example/experiment_automata/Experiments/ExperimentModel/ExperimentManager.java
@@ -1,5 +1,9 @@
 package com.example.experiment_automata.Experiments.ExperimentModel;
 
+import androidx.annotation.NonNull;
+
+import com.google.android.gms.tasks.OnFailureListener;
+import com.google.android.gms.tasks.OnSuccessListener;
 import com.google.firebase.firestore.FirebaseFirestore;
 
 import java.util.ArrayList;
@@ -156,8 +160,30 @@ public class ExperimentManager
     public void postExperimentToFirestore(Experiment experiment){
         FirebaseFirestore db = FirebaseFirestore.getInstance();
         Map<String,Object> experimentData = new HashMap<>();
+        String experimentUUIDString = experiment.getExperimentId().toString();
+        String experimentOwnerString = experiment.getOwnerId().toString();//not sure if needed in DB
+
+
+        experimentData.put("accepting-new-results",experiment.isActive());
         experimentData.put("description",experiment.getDescription());
         experimentData.put("location-required",experiment.isRequireLocation());
+        experimentData.put("min-trials",experiment.getMinTrials());
+        //experimentData.put("owner",experiment.getOwnerId());
+
+        db.collection("experiments").document(experimentUUIDString)
+                .set(experimentData)
+                .addOnSuccessListener(new OnSuccessListener<Void>() {
+                    @Override
+                    public void onSuccess(Void aVoid) {
+
+                    }
+                })
+                .addOnFailureListener(new OnFailureListener() {
+                    @Override
+                    public void onFailure(@NonNull Exception e) {
+
+                    }
+                });
     }
 
 

--- a/code/app/src/main/java/com/example/experiment_automata/Experiments/ExperimentModel/ExperimentManager.java
+++ b/code/app/src/main/java/com/example/experiment_automata/Experiments/ExperimentModel/ExperimentManager.java
@@ -150,10 +150,11 @@ public class ExperimentManager
     public void postAllToFirestore(){
         FirebaseFirestore db = FirebaseFirestore.getInstance();
 
+
     }
 
     /**
-     * Push all given experiment to firestore
+     * Push given experiment to firestore
      * @param experiment
      * experiment to post
      */

--- a/code/app/src/main/java/com/example/experiment_automata/Experiments/ExperimentModel/ExperimentManager.java
+++ b/code/app/src/main/java/com/example/experiment_automata/Experiments/ExperimentModel/ExperimentManager.java
@@ -149,8 +149,9 @@ public class ExperimentManager
      */
     public void postAllToFirestore(){
         FirebaseFirestore db = FirebaseFirestore.getInstance();
-
-
+        experiments.forEach((key,experiment) -> {
+            postExperimentToFirestore(experiment);
+        });
     }
 
     /**
@@ -159,6 +160,7 @@ public class ExperimentManager
      * experiment to post
      */
     public void postExperimentToFirestore(Experiment experiment){
+        //add key field?
         FirebaseFirestore db = FirebaseFirestore.getInstance();
         Map<String,Object> experimentData = new HashMap<>();
         String experimentUUIDString = experiment.getExperimentId().toString();

--- a/code/app/src/main/java/com/example/experiment_automata/Experiments/ExperimentModel/ExperimentManager.java
+++ b/code/app/src/main/java/com/example/experiment_automata/Experiments/ExperimentModel/ExperimentManager.java
@@ -145,7 +145,19 @@ public class ExperimentManager
      */
     public void postAllToFirestore(){
         FirebaseFirestore db = FirebaseFirestore.getInstance();
-        
+
+    }
+
+    /**
+     * Push all given experiment to firestore
+     * @param experiment
+     * experiment to post
+     */
+    public void postExperimentToFirestore(Experiment experiment){
+        FirebaseFirestore db = FirebaseFirestore.getInstance();
+        Map<String,Object> experimentData = new HashMap<>();
+        experimentData.put("description",experiment.getDescription());
+        experimentData.put("location-required",experiment.isRequireLocation());
     }
 
 

--- a/code/app/src/main/java/com/example/experiment_automata/Experiments/ExperimentModel/ExperimentManager.java
+++ b/code/app/src/main/java/com/example/experiment_automata/Experiments/ExperimentModel/ExperimentManager.java
@@ -4,6 +4,7 @@ import androidx.annotation.NonNull;
 
 import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
+import com.google.firebase.firestore.CollectionReference;
 import com.google.firebase.firestore.DocumentReference;
 import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.FirebaseFirestore;
@@ -28,6 +29,8 @@ public class ExperimentManager
 {
     private static HashMap<UUID, Experiment> experiments;
     private Experiment currentExperiment;
+    private FirebaseFirestore db;
+    private final CollectionReference expCollectionReference;
 
 
     /**
@@ -36,6 +39,8 @@ public class ExperimentManager
     public ExperimentManager()
     {
         experiments = new HashMap<UUID, Experiment>();
+        db = FirebaseFirestore.getInstance();
+        expCollectionReference =  db.collection("experiments");
     }
 
     /**
@@ -155,8 +160,8 @@ public class ExperimentManager
     public Experiment getExperimentFromFirestore(UUID experimentID) {
         ExperimentMaker maker = new ExperimentMaker();
         Experiment experiment;
-        FirebaseFirestore db = FirebaseFirestore.getInstance();
-        DocumentReference experimentDocRef = db.collection("experiments").document(experimentID.toString());
+        //FirebaseFirestore db = FirebaseFirestore.getInstance();
+        DocumentReference experimentDocRef = expCollectionReference.document(experimentID.toString());
         DocumentSnapshot experimentDocSnapshot = experimentDocRef.get().getResult();//Task --> DocumentSnapshot
         DocumentReference ownerDocument = (DocumentReference)experimentDocSnapshot.get("owner");
         UUID ownerID = UUID.fromString(ownerDocument.getId());//is the returned string the path or just the ID?
@@ -181,7 +186,7 @@ public class ExperimentManager
      * Post all experiments contained in current ExperimentManager to firestore
      */
     public void postAllToFirestore(){
-        FirebaseFirestore db = FirebaseFirestore.getInstance();
+        //FirebaseFirestore db = FirebaseFirestore.getInstance();
         experiments.forEach((key,experiment) -> {
             postExperimentToFirestore(experiment);
         });
@@ -194,7 +199,7 @@ public class ExperimentManager
      */
     public void postExperimentToFirestore(Experiment experiment){
         //add key field?
-        FirebaseFirestore db = FirebaseFirestore.getInstance();
+        //FirebaseFirestore db = FirebaseFirestore.getInstance();
         Map<String,Object> experimentData = new HashMap<>();
         String experimentUUIDString = experiment.getExperimentId().toString();
         DocumentReference owner = db.collection("users").document("/users" + experiment.getOwnerId().toString());
@@ -206,7 +211,7 @@ public class ExperimentManager
         experimentData.put("owner",owner);
         experimentData.put("type",experiment.getType().name());//enum to string
 
-        db.collection("experiments").document(experimentUUIDString)
+        expCollectionReference.document(experimentUUIDString)
                 .set(experimentData)
                 .addOnSuccessListener(new OnSuccessListener<Void>() {
                     @Override

--- a/code/app/src/main/java/com/example/experiment_automata/Experiments/ExperimentModel/ExperimentManager.java
+++ b/code/app/src/main/java/com/example/experiment_automata/Experiments/ExperimentModel/ExperimentManager.java
@@ -161,7 +161,7 @@ public class ExperimentManager
 
         if (experimentDocSnapshot.exists()){
             experiment = maker.makeExperiment(
-                    ExperimentType.Binomial,//temp; Type storage not implemented
+                    ExperimentType.valueOf((String) experimentDocSnapshot.get("type")),//String to ExperimentType
                     (String) experimentDocSnapshot.get("description"),
                     (int) experimentDocSnapshot.get("min-trials"),
                     (boolean) experimentDocSnapshot.get("location-required"),
@@ -202,7 +202,7 @@ public class ExperimentManager
         experimentData.put("location-required",experiment.isRequireLocation());
         experimentData.put("min-trials",experiment.getMinTrials());
         experimentData.put("owner",owner);
-        //experimentData.put("type",experiment.getType());
+        experimentData.put("type",experiment.getType().name());//enum to string
 
         db.collection("experiments").document(experimentUUIDString)
                 .set(experimentData)

--- a/code/app/src/main/java/com/example/experiment_automata/Experiments/ExperimentModel/ExperimentManager.java
+++ b/code/app/src/main/java/com/example/experiment_automata/Experiments/ExperimentModel/ExperimentManager.java
@@ -1,13 +1,18 @@
 package com.example.experiment_automata.Experiments.ExperimentModel;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
 import com.google.firebase.firestore.CollectionReference;
 import com.google.firebase.firestore.DocumentReference;
 import com.google.firebase.firestore.DocumentSnapshot;
+import com.google.firebase.firestore.EventListener;
 import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.FirebaseFirestoreException;
+import com.google.firebase.firestore.QueryDocumentSnapshot;
+import com.google.firebase.firestore.QuerySnapshot;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -41,6 +46,16 @@ public class ExperimentManager
         experiments = new HashMap<UUID, Experiment>();
         db = FirebaseFirestore.getInstance();
         expCollectionReference =  db.collection("experiments");
+
+        //experiments automatic realtime updates from databases taken from lab 5
+        expCollectionReference.addSnapshotListener(new EventListener<QuerySnapshot>() {
+            @Override
+            public void onEvent(@Nullable QuerySnapshot snapshots, @Nullable FirebaseFirestoreException error) {
+                for (QueryDocumentSnapshot doc : snapshots){
+
+                }
+            }
+        });
     }
 
     /**

--- a/code/app/src/main/java/com/example/experiment_automata/Experiments/ExperimentModel/ExperimentManager.java
+++ b/code/app/src/main/java/com/example/experiment_automata/Experiments/ExperimentModel/ExperimentManager.java
@@ -158,6 +158,8 @@ public class ExperimentManager
         FirebaseFirestore db = FirebaseFirestore.getInstance();
         DocumentReference experimentDocRef = db.collection("experiments").document(experimentID.toString());
         DocumentSnapshot experimentDocSnapshot = experimentDocRef.get().getResult();//Task --> DocumentSnapshot
+        DocumentReference ownerDocument = (DocumentReference)experimentDocSnapshot.get("owner");
+        UUID ownerID = UUID.fromString(ownerDocument.getId());//is the returned string the path or just the ID?
 
         if (experimentDocSnapshot.exists()){
             experiment = maker.makeExperiment(
@@ -166,7 +168,7 @@ public class ExperimentManager
                     (int) experimentDocSnapshot.get("min-trials"),
                     (boolean) experimentDocSnapshot.get("location-required"),
                     (boolean) experimentDocSnapshot.get("accepting-new-results"),
-                    UUID.fromString("00000000-0000-0000-0000-000000000000")//temp; UUID from documentReference not implemented
+                    ownerID//is this value path to document or the ID?
             );
             return experiment;
         }
@@ -176,7 +178,7 @@ public class ExperimentManager
     }
 
     /**
-     * Post all experiments to firestore
+     * Post all experiments contained in current ExperimentManager to firestore
      */
     public void postAllToFirestore(){
         FirebaseFirestore db = FirebaseFirestore.getInstance();


### PR DESCRIPTION
Untested since junit can't directly interact with firestore. In particular ownerID for `ExperimentManager.getExperimentFromFirestore()` may not work the way I think it does. I'd like some feedback from @TurtleSquad007 about how/if SnapshotListener should be implemented.

Major additions:
- `ExperimentManager.postExperimentToFirestore(Experiment experiment)`
- `ExperimentManager.postAllToFirestore()`
- `ExperimentManager.getExperimentFromFirestore(UUID experimentID)`
- empty firestore `SnapshotListener` for Experiment Manager
