### PR TITLE
Show experiment owner name

### DIFF
--- a/code/app/src/main/java/com/example/experiment_automata/ui/NavigationActivity.java
+++ b/code/app/src/main/java/com/example/experiment_automata/ui/NavigationActivity.java
@@ -215,7 +215,6 @@ public class NavigationActivity extends AppCompatActivity implements
                 Bundle bundle = new Bundle();
                 bundle.putString("query", query);
                 navController.navigate(R.id.nav_search, bundle);
-                searchView.setQuery("", false);
                 return false;
             }
 

--- a/code/app/src/main/java/com/example/experiment_automata/ui/experiments/ExperimentListAdapter.java
+++ b/code/app/src/main/java/com/example/experiment_automata/ui/experiments/ExperimentListAdapter.java
@@ -2,6 +2,7 @@ package com.example.experiment_automata.ui.experiments;
 
 import android.content.Context;
 import android.graphics.Color;
+import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -11,9 +12,15 @@ import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.navigation.NavController;
+import androidx.navigation.Navigation;
 
 import com.example.experiment_automata.backend.experiments.Experiment;
 import com.example.experiment_automata.R;
+import com.example.experiment_automata.backend.users.User;
+import com.example.experiment_automata.ui.LinkView;
+import com.example.experiment_automata.ui.NavigationActivity;
+import com.example.experiment_automata.ui.profile.ProfileFragment;
 
 import java.util.ArrayList;
 import java.util.UUID;
@@ -72,7 +79,7 @@ public class ExperimentListAdapter extends ArrayAdapter<Experiment> {
 
         // Find the corresponding views from experiment_layout
         TextView name = view.findViewById(R.id.experimentName);
-        TextView owner = view.findViewById(R.id.experimentOwner);
+        LinkView owner = view.findViewById(R.id.experimentOwner);
         TextView active = view.findViewById(R.id.experimentActivity);
         TextView experimentID = view.findViewById(R.id.experiment__id);
         CheckBox publishedCheckbox = view.findViewById(R.id.publishedCheckbox);
@@ -80,6 +87,17 @@ public class ExperimentListAdapter extends ArrayAdapter<Experiment> {
         // Set the name of the experiment accordingly
         UUID oid = exp.getOwnerId();
         name.setText(exp.getDescription());
+
+        // Set the name of the experiment owner
+        User user = User.getInstance(exp.getOwnerId());
+        owner.setText(user.getInfo().getName());
+        owner.setOnClickListener(v -> {
+            NavigationActivity parentActivity = (NavigationActivity) context;
+            Bundle args = new Bundle();
+            args.putSerializable(ProfileFragment.userKey, user);
+            NavController navController = Navigation.findNavController(parentActivity, R.id.nav_host_fragment);
+            navController.navigate(R.id.nav_profile, args);
+        });
 
         // Set the activity properly
         boolean isActive = exp.isActive();

--- a/code/app/src/main/java/com/example/experiment_automata/ui/profile/ProfileFragment.java
+++ b/code/app/src/main/java/com/example/experiment_automata/ui/profile/ProfileFragment.java
@@ -72,14 +72,18 @@ public class ProfileFragment extends Fragment {
         profileViewModel.getName().observe(getViewLifecycleOwner(), nameView::setText);
         profileViewModel.getEmail().observe(getViewLifecycleOwner(), emailView::setText);
         profileViewModel.getPhone().observe(getViewLifecycleOwner(), phoneView::setText);
-        editButton.setOnClickListener(v -> {
-            Fragment editUserFragment = new EditUserFragment();
-            Bundle bundle = new Bundle();
-            bundle.putSerializable(EditUserFragment.bundleUserKey, user);
-            editUserFragment.setArguments(bundle);
-            getActivity().getSupportFragmentManager().beginTransaction()
-                    .add(editUserFragment, "USER").commit();
-        });
+        if (parentActivity.loggedUser == user) {
+            editButton.setOnClickListener(v -> {
+                Fragment editUserFragment = new EditUserFragment();
+                Bundle bundle = new Bundle();
+                bundle.putSerializable(EditUserFragment.bundleUserKey, user);
+                editUserFragment.setArguments(bundle);
+                getActivity().getSupportFragmentManager().beginTransaction()
+                        .add(editUserFragment, "USER").commit();
+            });
+        } else {
+            editButton.setVisibility(View.GONE);
+        }
         fab = parentActivity.findViewById(R.id.fab_button);
         fab.setVisibility(View.GONE);
         return root;

--- a/code/app/src/main/res/layout/experiment_layout.xml
+++ b/code/app/src/main/res/layout/experiment_layout.xml
@@ -20,14 +20,14 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <TextView
+    <com.example.experiment_automata.ui.LinkView
         android:id="@+id/experimentOwner"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
         android:layout_marginEnd="16dp"
-        android:layout_marginRight="16dp"
         android:text="Experiment Owner"
+        android:textColor="?android:attr/textColorLink"
         android:textSize="18sp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/experimentName" />


### PR DESCRIPTION
Replace the placeholder text on any experiment list view with the experiment's owner's name. This also links to the profile. When viewing a profile that isn't of the logged-in user, no edit button appears.