### PR TITLE
Navigate on qr

### DIFF
--- a/code/app/src/main/java/com/example/experiment_automata/backend/experiments/ExperimentManager.java
+++ b/code/app/src/main/java/com/example/experiment_automata/backend/experiments/ExperimentManager.java
@@ -142,23 +142,7 @@ public class ExperimentManager {
         Collections.sort(experimentsList);
         return experimentsList;
     }
-    /**
-     * Check if a given experiment ID is published
-     * @param experimentID
-     * experiment ID to check
-     * @return
-     * if the experiment is published
-     */
-    public boolean isExperimentPublished(UUID experimentID){
-        ArrayList<Experiment<?>> experiments = getPublishedExperiments();
-        for(Experiment experiment : experiments){
-            //if(experiment.getExperimentId() == experimentID){
-            if(experimentID.compareTo(experiment.getExperimentId()) == 0){
-                return true;
-            }
-        }
-        return false;
-    }
+
 
     /**
      * returns the experiments current UUID
@@ -364,16 +348,7 @@ public class ExperimentManager {
         location.setLongitude(longitude);
         return  location;
     }
-    /**
-     * Checks if experimentManager contains a particular Experiment
-     * @param experimentID
-     *  experiment ID repersenting the experiment
-     * @return
-     *  if the experiment is in the app
-     */
-    public boolean containsExperiment(UUID experimentID){
-        return experiments.containsKey(experimentID);
-    }
+
     /**
      * Gets a specific Experiment
      * @param experimentID

--- a/code/app/src/main/java/com/example/experiment_automata/backend/experiments/ExperimentManager.java
+++ b/code/app/src/main/java/com/example/experiment_automata/backend/experiments/ExperimentManager.java
@@ -24,7 +24,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Role/Pattern:

--- a/code/app/src/main/java/com/example/experiment_automata/ui/qr/ScanQRFragment.java
+++ b/code/app/src/main/java/com/example/experiment_automata/ui/qr/ScanQRFragment.java
@@ -126,7 +126,7 @@ public class ScanQRFragment extends Fragment {
                     Snackbar.make(requireView(), message, Snackbar.LENGTH_LONG).show();
                 }
             } else {
-                Snackbar.make(requireView(), "You are not subscribed to the Experiment contained in the scanned QR code", Snackbar.LENGTH_LONG).show();
+                Snackbar.make(requireView(), "The Experiment contained in the scanned QR code is not published or isn't accepting results", Snackbar.LENGTH_LONG).show();
             }
         } catch (QRMalformattedException qrMalE){
             //malformatted QR
@@ -170,7 +170,7 @@ public class ScanQRFragment extends Fragment {
                 Snackbar.make(requireView(), message, Snackbar.LENGTH_LONG).show();
             } else {
                 experiment = null;
-                Snackbar.make(requireView(),"The scanned barcode is not published",Snackbar.LENGTH_LONG).show();
+                Snackbar.make(requireView(),"The Experiment contained in the scanned barcode is not published or isn't accepting results",Snackbar.LENGTH_LONG).show();
             }
         }
     }

--- a/code/app/src/main/java/com/example/experiment_automata/ui/qr/ScanQRFragment.java
+++ b/code/app/src/main/java/com/example/experiment_automata/ui/qr/ScanQRFragment.java
@@ -8,6 +8,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.navigation.NavController;
@@ -27,6 +28,7 @@ import com.example.experiment_automata.backend.trials.NaturalCountTrial;
 import com.example.experiment_automata.backend.trials.Trial;
 import com.example.experiment_automata.backend.users.User;
 import com.example.experiment_automata.ui.NavigationActivity;
+import com.example.experiment_automata.ui.experiments.NavExperimentDetailsFragment;
 import com.google.android.material.snackbar.Snackbar;
 
 import java.util.Collection;
@@ -36,36 +38,16 @@ import java.util.UUID;
  * Fragment for setting up scanning QR codes and barcodes from the hamburger menu. It opens a ScannerActivity.
  *
  * A simple {@link Fragment} subclass.
- * Use the {@link ScanQRFragment#newInstance} factory method to
- * create an instance of this fragment.
  */
 public class ScanQRFragment extends Fragment {
     private NavigationActivity parentActivity;
     private ExperimentManager experimentManager;
-    // TODO: Rename and change types of parameters
-    private String mParam1;
-    private String mParam2;
+    private User user;
+    private Trial<?> trial;
+    private Experiment experiment;
 
     public ScanQRFragment() {
         // Required empty public constructor
-    }
-
-    /**
-     * Use this factory method to create a new instance of
-     * this fragment using the provided parameters.
-     *
-     * @param param1 Parameter 1.
-     * @param param2 Parameter 2.
-     * @return A new instance of fragment ScanQR.
-     */
-    // TODO: Rename and change types and number of parameters
-    public static ScanQRFragment newInstance(String param1, String param2) {
-        ScanQRFragment fragment = new ScanQRFragment();
-        Bundle args = new Bundle();
-        //args.putString(ARG_PARAM1, param1);
-        //args.putString(ARG_PARAM2, param2);
-        fragment.setArguments(args);
-        return fragment;
     }
 
     @Override
@@ -74,7 +56,7 @@ public class ScanQRFragment extends Fragment {
         parentActivity = ((NavigationActivity) getActivity());
         experimentManager = parentActivity.experimentManager;
         Intent intent = new Intent(getActivity(), ScannerActivity.class);
-        startActivityForResult(intent,1);
+        startActivityForResult(intent, 1);
 
     }
 
@@ -88,126 +70,108 @@ public class ScanQRFragment extends Fragment {
     @Override
     public void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {//when the ScannerActivity is finished
         super.onActivityResult(requestCode, resultCode, data);
+        NavController navController = Navigation.findNavController(requireView());
         if (data == null) {
+            navController.navigateUp();
             return;
         }
-        Trial trial;
-        User user = parentActivity.loggedUser;
-        String rawScannedContrent = data.getStringExtra("QRCONTENTRAW");
-        if (data.getBooleanExtra("IS_QR",true)){//Scanned obj was QR
-            QRCode qrCode;
-            QRMaker qrMaker = new QRMaker();
-            try{
-                Collection<UUID> subscriptions = user.getSubscriptions();
-                qrCode = qrMaker.decodeQRString(rawScannedContrent);
-                //scanned valid QR
-                if (subscriptions.contains(qrCode.getExperimentID())){//experimentManager.containsExperiment(qrCode.getExperimentID())
-                    //add location ability later
-                    switch (qrCode.getType()){
-                        case BinomialTrial:
-                            trial = new BinomialTrial(user.getUserId(),(Boolean) qrCode.getValue());
-                            Experiment binExperiment =  experimentManager.getExperiment(qrCode.getExperimentID());
-                            if(binExperiment.isRequireLocation()){
-                                parentActivity.addLocationToTrial(trial);
-                            }
-                            parentActivity.addTrial(binExperiment,trial);
-                            Snackbar.make(getView(),"Binomial Trial with value " + qrCode.getValue() + " scanned successfully in "+ binExperiment.getDescription(),Snackbar.LENGTH_LONG).show();
-                            break;
-                        case CountTrial:
-                            trial = new CountTrial(user.getUserId());
-                            Experiment countExperiment =  experimentManager.getExperiment(qrCode.getExperimentID());
-                            if(countExperiment.isRequireLocation()){
-                                parentActivity.addLocationToTrial(trial);
-                            }
-                            parentActivity.addTrial(countExperiment,trial);
-                            Snackbar.make(getView(),"Count Trial with value " + qrCode.getValue() + " scanned successfully in "+ countExperiment.getDescription(),Snackbar.LENGTH_LONG).show();
-                            break;
-                        case NaturalCountTrial:
-                            trial = new NaturalCountTrial(user.getUserId(),(int) qrCode.getValue());
-                            Experiment natExperiment = experimentManager.getExperiment(qrCode.getExperimentID());
-                            if(natExperiment.isRequireLocation()){
-                                parentActivity.addLocationToTrial(trial);
-                            }
-                            parentActivity.addTrial(natExperiment,trial);
-                            Snackbar.make(getView(),"NaturalCount Trial with value " + qrCode.getValue() + " scanned successfully in "+ natExperiment.getDescription(),Snackbar.LENGTH_LONG).show();
-                            break;
-                        case MeasurementTrial:
-                            trial = new MeasurementTrial(user.getUserId(),(float) qrCode.getValue());
-                            Experiment mesExperiment = experimentManager.getExperiment(qrCode.getExperimentID());
-                            if(mesExperiment.isRequireLocation()){
-                                parentActivity.addLocationToTrial(trial);
-                            }
-                            parentActivity.addTrial(mesExperiment,trial);
-                            Snackbar.make(getView(),"Measurement Trial with value " + qrCode.getValue() + " scanned successfully in " + mesExperiment.getDescription(),Snackbar.LENGTH_LONG).show();
-
-                            break;
-                        case Experiment:
-                            //move to screen
-                            break;
-                    }
-
-                }
-                else{
-                    Snackbar.make(getView(),"You are not subscribed to the Experiment contained in the scanned QR code",Snackbar.LENGTH_LONG).show();
-                }
-            }
-            catch (QRMalformattedException qrMalE){
-                //malformatted QR
-                qrCode = null;
-                Log.d("SCANNER","Scanned Malformatted QR");
-                Snackbar.make(getView(),"Scanned QR was not an Experiment-Automata QR Code",Snackbar.LENGTH_LONG).show();
-
-            }
+        user = parentActivity.loggedUser;
+        String rawScannedContent = data.getStringExtra("QRCONTENTRAW");
+        if (data.getBooleanExtra("IS_QR",true)) {
+            handleQR(rawScannedContent);
+        } else {
+            handleBarcode(rawScannedContent);
         }
-        else{//scanned obj was barcode
-            Log.d("SCANNER","Barcode was scanned");
-            BarcodeReference barcodeReference = parentActivity.barcodeManager.getBarcode(rawScannedContrent);
-            if (barcodeReference == null) {
-                //barcode not associated
-                Snackbar.make(getView(),"Scanned barcode has not been associated with a valid Trial yet",Snackbar.LENGTH_LONG).show();
-            }
-            else{
-                //add given Trial to experiment
-                Snackbar.make(getView(),"Scanned barcode was found!",Snackbar.LENGTH_LONG).show();
-                UUID barcodeExperimentID = barcodeReference.getExperimentId();
-                Location barcodeLocation = barcodeReference.getLocation();
-                if(parentActivity.experimentManager.isExperimentPublished(barcodeExperimentID)){
-                    switch (barcodeReference.getType()){
-                        case Binomial:
-                            trial = new BinomialTrial(user.getUserId(),barcodeLocation,(Boolean) barcodeReference.getResult());
-                            Experiment binExperiment =  experimentManager.getExperiment(barcodeExperimentID);
-                            parentActivity.addTrial(binExperiment,trial);
-                            Snackbar.make(getView(),"Binomial Trial with value " + barcodeReference.getResult() + " scanned successfully in "+ binExperiment.getDescription(),Snackbar.LENGTH_LONG).show();
-                            break;
-                        case Count:
-                            trial = new CountTrial(user.getUserId(),barcodeLocation);
-                            Experiment countExperiment =  experimentManager.getExperiment(barcodeExperimentID);
-                            parentActivity.addTrial(countExperiment,trial);
-                            Snackbar.make(getView(),"Count Trial with value " + barcodeReference.getResult() + " scanned successfully in "+ countExperiment.getDescription(),Snackbar.LENGTH_LONG).show();
-                            break;
-                        case NaturalCount:
-                            trial = new NaturalCountTrial(user.getUserId(),barcodeLocation,(int) barcodeReference.getResult());
-                            Experiment natExperiment =  experimentManager.getExperiment(barcodeExperimentID);
-                            parentActivity.addTrial(natExperiment,trial);
-                            Snackbar.make(getView(),"NaturalCount Trial with value " + barcodeReference.getResult() + " scanned successfully in "+ natExperiment.getDescription(),Snackbar.LENGTH_LONG).show();
-                            break;
-                        case Measurement:
-                            trial = new MeasurementTrial(user.getUserId(),barcodeLocation,(float) barcodeReference.getResult());
-                            Experiment mesExperiment =  experimentManager.getExperiment(barcodeExperimentID);
-                            parentActivity.addTrial(mesExperiment,trial);
-                            Snackbar.make(getView(),"Measurement Trial with value " + barcodeReference.getResult() + " scanned successfully in "+ mesExperiment.getDescription(),Snackbar.LENGTH_LONG).show();
-                            break;
-                    }
-                }
-                else{
-                    Snackbar.make(getView(),"The scanned barcode is not published",Snackbar.LENGTH_LONG).show();
-                }
-            }
-        }
-        NavController navController = Navigation.findNavController(getView());
-        navController.navigateUp();//return to parent
+        navController.navigateUp();
+        Bundle args = new Bundle();
+        args.putString(NavExperimentDetailsFragment.CURRENT_EXPERIMENT_ID,
+                experiment.getExperimentId().toString());
+        parentActivity.experimentManager.setCurrentExperiment(experiment);
+        navController.navigate(R.id.nav_experiment_details, args);
     }
 
+    private void handleQR(@NonNull String scannedContent) {
+        QRCode qrCode;
+        QRMaker qrMaker = new QRMaker();
+        try {
+            Collection<UUID> subscriptions = user.getSubscriptions();
+            qrCode = qrMaker.decodeQRString(scannedContent);
+            //scanned valid QR
+            if (subscriptions.contains(qrCode.getExperimentID())){//experimentManager.containsExperiment(qrCode.getExperimentID())
+                //add location ability later
+                experiment = experimentManager.getExperiment(qrCode.getExperimentID());
+                switch (qrCode.getType()){
+                    case BinomialTrial:
+                        trial = new BinomialTrial(user.getUserId(), (boolean) qrCode.getValue());
+                        break;
+                    case CountTrial:
+                        trial = new CountTrial(user.getUserId());
+                        break;
+                    case NaturalCountTrial:
+                        trial = new NaturalCountTrial(user.getUserId(), (int) qrCode.getValue());
+                        break;
+                    case MeasurementTrial:
+                        trial = new MeasurementTrial(user.getUserId(), (float) qrCode.getValue());
 
+                        break;
+                    case Experiment:
+                        break;
+                }
+                if (trial != null) {
+                    if (experiment.isRequireLocation()) {
+                        parentActivity.addLocationToTrial(trial);
+                    }
+                    parentActivity.addTrial(experiment, trial);
+                    final String message = String.format("%s Trial with value %s scanned successfully in %s",
+                            experiment.getType(), qrCode.getValue(), experiment.getDescription());
+                    Snackbar.make(requireView(), message, Snackbar.LENGTH_LONG).show();
+                }
+            } else {
+                Snackbar.make(requireView(), "You are not subscribed to the Experiment contained in the scanned QR code", Snackbar.LENGTH_LONG).show();
+            }
+        } catch (QRMalformattedException qrMalE){
+            //malformatted QR
+            qrCode = null;
+            Log.d("SCANNER","Scanned Malformatted QR");
+            Snackbar.make(requireView(), "Scanned QR was not an Experiment-Automata QR Code", Snackbar.LENGTH_LONG).show();
+        }
+    }
 
+    private void handleBarcode(@NonNull String scannedContent) {
+        Log.d("SCANNER","Barcode was scanned");
+        BarcodeReference barcodeReference = parentActivity.barcodeManager.getBarcode(scannedContent);
+        if (barcodeReference == null) {
+            //barcode not associated
+            Snackbar.make(requireView(), "Scanned barcode has not been associated with a valid Trial yet", Snackbar.LENGTH_LONG).show();
+        } else {
+            //add given Trial to experiment
+            Snackbar.make(requireView(),"Scanned barcode was found!",Snackbar.LENGTH_LONG).show();
+            UUID barcodeExperimentID = barcodeReference.getExperimentId();
+            Location barcodeLocation = barcodeReference.getLocation();
+            experiment = null;
+            if(parentActivity.experimentManager.isExperimentPublished(barcodeExperimentID)){
+                experiment =  experimentManager.getExperiment(barcodeExperimentID);
+                switch (barcodeReference.getType()){
+                    case Binomial:
+                        trial = new BinomialTrial(user.getUserId(), barcodeLocation,(Boolean) barcodeReference.getResult());
+                        break;
+                    case Count:
+                        trial = new CountTrial(user.getUserId(), barcodeLocation);
+                        break;
+                    case NaturalCount:
+                        trial = new NaturalCountTrial(user.getUserId(), barcodeLocation, (int) barcodeReference.getResult());
+                        break;
+                    case Measurement:
+                        trial = new MeasurementTrial(user.getUserId(), barcodeLocation, (float) barcodeReference.getResult());
+                        break;
+                }
+                parentActivity.addTrial(experiment, trial);
+                final String message = String.format("%s Trial with value %s scanned successfully in %s",
+                        experiment.getType(), barcodeReference.getResult(), experiment.getDescription());
+                Snackbar.make(requireView(), message, Snackbar.LENGTH_LONG).show();
+            } else {
+                Snackbar.make(requireView(),"The scanned barcode is not published",Snackbar.LENGTH_LONG).show();
+            }
+        }
+    }
 }

--- a/code/app/src/main/java/com/example/experiment_automata/ui/qr/ScanQRFragment.java
+++ b/code/app/src/main/java/com/example/experiment_automata/ui/qr/ScanQRFragment.java
@@ -97,9 +97,8 @@ public class ScanQRFragment extends Fragment {
             Collection<UUID> subscriptions = user.getSubscriptions();
             qrCode = qrMaker.decodeQRString(scannedContent);
             //scanned valid QR
-            if (subscriptions.contains(qrCode.getExperimentID())){//experimentManager.containsExperiment(qrCode.getExperimentID())
-                //add location ability later
-                experiment = experimentManager.getExperiment(qrCode.getExperimentID());
+            experiment = experimentManager.getExperiment(qrCode.getExperimentID());
+            if (experiment.isPublished() && experiment.isActive()){
                 switch (qrCode.getType()){
                     case BinomialTrial:
                         trial = new BinomialTrial(user.getUserId(), (boolean) qrCode.getValue());
@@ -148,8 +147,8 @@ public class ScanQRFragment extends Fragment {
             Snackbar.make(requireView(),"Scanned barcode was found!",Snackbar.LENGTH_LONG).show();
             UUID barcodeExperimentID = barcodeReference.getExperimentId();
             Location barcodeLocation = barcodeReference.getLocation();
-            experiment = null;
-            if(parentActivity.experimentManager.isExperimentPublished(barcodeExperimentID)){
+            experiment =  experimentManager.getExperiment(barcodeExperimentID);
+            if(experiment.isPublished() && experiment.isActive()){
                 experiment =  experimentManager.getExperiment(barcodeExperimentID);
                 switch (barcodeReference.getType()){
                     case Binomial:
@@ -170,6 +169,7 @@ public class ScanQRFragment extends Fragment {
                         experiment.getType(), barcodeReference.getResult(), experiment.getDescription());
                 Snackbar.make(requireView(), message, Snackbar.LENGTH_LONG).show();
             } else {
+                experiment = null;
                 Snackbar.make(requireView(),"The scanned barcode is not published",Snackbar.LENGTH_LONG).show();
             }
         }

--- a/code/app/src/main/java/com/example/experiment_automata/ui/qr/ScannerActivity.java
+++ b/code/app/src/main/java/com/example/experiment_automata/ui/qr/ScannerActivity.java
@@ -34,29 +34,21 @@ public class ScannerActivity extends AppCompatActivity {
         integrator.setOrientationLocked(false);//enable screen rotation for zxing activity in manifest
         integrator.initiateScan();
     }
+
     @Override
     protected void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
         IntentResult result = IntentIntegrator.parseActivityResult(requestCode, resultCode, data);
         super.onActivityResult(requestCode, resultCode, data);
-        if(result != null) {
+        if (result != null) {
             if(result.getContents() == null) {
-                Log.d("SCANNER","Canceled scan" );
+                Log.d("SCANNER", "Canceled scan");
             } else {
                 Log.d("SCANNER","Scanned: " + result.getContents() + " of type " + result.getContents().getClass().getName());
                 Intent resultIntent = new Intent();
-                resultIntent.putExtra("QRCONTENTRAW",result.getContents());
-
-                if(result.getFormatName().equals(IntentIntegrator.QR_CODE)){//qrCode
-                    resultIntent.putExtra("IS_QR",true);
-                }
-                else{//barcode
-                    resultIntent.putExtra("IS_QR",false);
-                }
-
-                setResult(1,resultIntent);
+                resultIntent.putExtra("QRCONTENTRAW", result.getContents());
+                resultIntent.putExtra("IS_QR", result.getFormatName().equals(IntentIntegrator.QR_CODE));
+                setResult(1, resultIntent);
             }
-        } else {
-            super.onActivityResult(requestCode, resultCode, data);
         }
         finish();
     }

--- a/code/app/src/main/java/com/example/experiment_automata/ui/trials/add/AddMeasurementTrialFragment.java
+++ b/code/app/src/main/java/com/example/experiment_automata/ui/trials/add/AddMeasurementTrialFragment.java
@@ -34,7 +34,6 @@ import org.osmdroid.views.MapView;
 
 /**
  * A simple {@link Fragment} subclass.
- * Use the {@link AddMeasurementTrialFragment#newInstance} factory method to
  * create an instance of this fragment.
  */
 public class AddMeasurementTrialFragment extends Fragment {
@@ -68,12 +67,14 @@ public class AddMeasurementTrialFragment extends Fragment {
 
         scanQRButton = root.findViewById(R.id.add_measurement_qr_button);
         scanQRButton.setOnClickListener(new View.OnClickListener(){
-
             @Override
-            public void onClick(View v) {//open scanner
-                Intent intent = new Intent(getActivity(), ScannerActivity.class);
-                startActivityForResult(intent,1);
-                //startActivity(intent);
+            public void onClick(View v) {
+                if (measurementValue.getText().toString().isEmpty()) {
+                    Snackbar.make(root, "Cannot associate barcode with empty value", Snackbar.LENGTH_LONG).show();
+                } else {
+                    Intent intent = new Intent(getActivity(), ScannerActivity.class);
+                    startActivityForResult(intent, 1);
+                }
 
             }
         });
@@ -104,6 +105,7 @@ public class AddMeasurementTrialFragment extends Fragment {
         utility.run();
         return root;
     }
+
     @Override
     public void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
@@ -141,9 +143,13 @@ public class AddMeasurementTrialFragment extends Fragment {
             Location location = parentActivity.currentTrial.getLocation();
             BarcodeManager testBC = parentActivity.barcodeManager;
             MeasurementExperiment experiment = (MeasurementExperiment) parentActivity.experimentManager.getCurrentExperiment();
-            float trialValue = Float.parseFloat(measurementValue.getText().toString());
-            parentActivity.barcodeManager.addBarcode(rawQRContent,experiment.getExperimentId(),trialValue,location);
-            Snackbar.make(root, "Scanned Barcode " + rawQRContent + " was associated with this Trials Value", Snackbar.LENGTH_LONG).show();
+            try {
+                float trialValue = Float.parseFloat(measurementValue.getText().toString());
+                parentActivity.barcodeManager.addBarcode(rawQRContent, experiment.getExperimentId(), trialValue, location);
+                Snackbar.make(root, "Scanned Barcode " + rawQRContent + " was associated with this Trials Value", Snackbar.LENGTH_LONG).show();
+            } catch (NumberFormatException e) {
+                Snackbar.make(root, "Cannot associate barcode with empty value", Snackbar.LENGTH_LONG).show();
+            }
         }
     }
 

--- a/code/app/src/main/java/com/example/experiment_automata/ui/trials/add/AddNaturalCountTrialFragment.java
+++ b/code/app/src/main/java/com/example/experiment_automata/ui/trials/add/AddNaturalCountTrialFragment.java
@@ -33,7 +33,6 @@ import org.osmdroid.views.MapView;
 
 /**
  * A simple {@link Fragment} subclass.
- * Use the {@link AddNaturalCountTrialFragment#newInstance} factory method to
  * create an instance of this fragment.
  */
 public class AddNaturalCountTrialFragment extends Fragment {
@@ -69,9 +68,12 @@ public class AddNaturalCountTrialFragment extends Fragment {
 
             @Override
             public void onClick(View v) {//open scanner
-                Intent intent = new Intent(getActivity(), ScannerActivity.class);
-                startActivityForResult(intent,1);
-                //startActivity(intent);
+                if (countValue.getText().toString().isEmpty()) {
+                    Snackbar.make(root, "Cannot associate barcode with empty value", Snackbar.LENGTH_LONG).show();
+                } else {
+                    Intent intent = new Intent(getActivity(), ScannerActivity.class);
+                    startActivityForResult(intent, 1);
+                }
 
             }
         });
@@ -102,6 +104,7 @@ public class AddNaturalCountTrialFragment extends Fragment {
         utility.run();
         return root;
     }
+
     @Override
     public void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
@@ -139,9 +142,13 @@ public class AddNaturalCountTrialFragment extends Fragment {
             Location location = parentActivity.currentTrial.getLocation();
             BarcodeManager testBC = parentActivity.barcodeManager;
             NaturalCountExperiment experiment = (NaturalCountExperiment) parentActivity.experimentManager.getCurrentExperiment();
-            int trialValue = Integer.valueOf(countValue.getText().toString());
-            parentActivity.barcodeManager.addBarcode(rawQRContent,experiment.getExperimentId(),trialValue,location);
-            Snackbar.make(root, "Scanned Barcode " + rawQRContent + " was associated with this Trials Value", Snackbar.LENGTH_LONG).show();
+            try {
+                int trialValue = Integer.valueOf(countValue.getText().toString());
+                parentActivity.barcodeManager.addBarcode(rawQRContent,experiment.getExperimentId(),trialValue,location);
+                Snackbar.make(root, "Scanned Barcode " + rawQRContent + " was associated with this Trials Value", Snackbar.LENGTH_LONG).show();
+            } catch (NumberFormatException e) {
+                Snackbar.make(root, "Cannot associate barcode with empty value", Snackbar.LENGTH_LONG).show();
+            }
         }
     }
 


### PR DESCRIPTION
Navigate to the experiment detail page when you've scanned a QR code or barcode. Also fixed a bug where you could scan a barcode to associate to a trial, but no trial value was inputted by the user.